### PR TITLE
Changed fileName storage method and Report Creation Photo Preview Size

### DIFF
--- a/Core/res/values-v11/dimens.xml
+++ b/Core/res/values-v11/dimens.xml
@@ -2,8 +2,8 @@
 <resources>
 
     <!-- dimensions for upload photo preview -->
-    <dimen name="preview_photo_width">75dp</dimen>
-    <dimen name="preview_photo_height">75dp</dimen>
+    <dimen name="preview_photo_width">150dp</dimen>
+    <dimen name="preview_photo_height">150dp</dimen>
     <dimen name="mapview_height">250dp</dimen>
     <dimen name="colorstrip_height">4dp</dimen>
     <dimen name="corner_radius">8dp</dimen>

--- a/Core/src/com/ushahidi/android/app/api/ReportsApi.java
+++ b/Core/src/com/ushahidi/android/app/api/ReportsApi.java
@@ -97,8 +97,8 @@ public class ReportsApi extends UshahidiApi {
                                         // save photo to a file
 
                                         if (m.getLinkUrl() != null) {
-                                            final String fileName = Util
-                                                    .getDateTime() + ".jpg";
+                                        	//This will capture entire picture descriptor to prevent duplicates
+                                            final String fileName = m.getLinkUrl().substring(m.getLinkUrl().lastIndexOf('/')+1, m.getLinkUrl().length());
                                             // save details of photo to database
                                             saveMedia(m.getId(),
                                                     i.incident.getId(),

--- a/Core/src/com/ushahidi/android/app/ui/phone/AddReportActivity.java
+++ b/Core/src/com/ushahidi/android/app/ui/phone/AddReportActivity.java
@@ -871,7 +871,7 @@ public class AddReportActivity extends
 					view.mPickDate.setText(simpleDateFormat.format(date));
 
 					SimpleDateFormat timeFormat = new SimpleDateFormat(
-							"h:mm a", Locale.US);
+							"h:mm a", Locale.FR);
 					view.mPickTime.setText(timeFormat.format(date));
 
 				} else {


### PR DESCRIPTION
fileName storage was based on time and date. There is a conflict with this when multiple files are submitted on the same second. Changed so the files are saved via unique system links.

Also changed photo preview size from 75x75 to 150x150. There was a complaint that the size of uploaded photos on android were shown too small. Increased preview size so the user can see the uploaded photo better before creating report. 
